### PR TITLE
fix get from empty persistent cause sigabrt or badaccess

### DIFF
--- a/include/v8.h
+++ b/include/v8.h
@@ -1110,6 +1110,7 @@ public:
     JSValue store_;
     
     V8_INLINE Local<T> Get(Isolate* isolate) const {
+        if (IsEmpty()) return Local<T>();
         Local<T> ret = val_.Clone(isolate, (Value*)(&this->store_));
         ret.IncRef(isolate);
         return ret;


### PR DESCRIPTION
1. 对IsEmpty的PersistentBase进行Get，得到的Local变量IsEmpty应为true实为false，此行为和v8不一致。
2. Get操作所得到的Local会进入ContextScope，且在Scope销毁时会尝试对该Local的JSValue进行Free操作。而这个JSValue是一个没有初始化的结构体。因此概率性会导致crash。