### PR TITLE
migrate to vs2022 to compat with win11

### DIFF
--- a/.github/workflows/build_quickjs.yml
+++ b/.github/workflows/build_quickjs.yml
@@ -174,7 +174,7 @@ jobs:
 
   build_window_dll:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - uses: msys2/setup-msys2@v2
@@ -209,7 +209,7 @@ jobs:
         
   build_window_dll_md:
     name: Windows MD
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - name: Insatll MSVC
@@ -246,7 +246,7 @@ jobs:
         
   build_window_dll_md_dll:
     name: Windows MD_dll
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - name: Insatll MSVC
@@ -284,7 +284,7 @@ jobs:
 
   build_window_dll32:
     name: Windows32
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - uses: msys2/setup-msys2@v2

--- a/.github/workflows/build_quickjs_qjs_ns.yml
+++ b/.github/workflows/build_quickjs_qjs_ns.yml
@@ -174,7 +174,7 @@ jobs:
 
   build_window_dll:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - uses: msys2/setup-msys2@v2
@@ -209,7 +209,7 @@ jobs:
         
   build_window_dll_md:
     name: Windows MD
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - name: Insatll MSVC
@@ -246,7 +246,7 @@ jobs:
         
   build_window_dll_md_dll:
     name: Windows MD_dll
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - name: Insatll MSVC
@@ -284,7 +284,7 @@ jobs:
 
   build_window_dll32:
     name: Windows32
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
     - uses: msys2/setup-msys2@v2

--- a/win/make_win32.bat
+++ b/win/make_win32.bat
@@ -1,9 +1,9 @@
 mkdir build & pushd build
 
 if "%1" == "1" (
-  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQJS_NS=1 -G "Visual Studio 16 2019" -A Win32 ..
+  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQJS_NS=1 -G "Visual Studio 17 2022" -A Win32 ..
 ) else (
-  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "Visual Studio 16 2019" -A Win32 ..
+  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "Visual Studio 17 2022" -A Win32 ..
 )
 popd
 cmake --build build --config Release

--- a/win/make_win64.bat
+++ b/win/make_win64.bat
@@ -1,9 +1,9 @@
 mkdir build & pushd build
 
 if "%1" == "1" (
-  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQJS_NS=1 -G "Visual Studio 16 2019" -A x64 ..
+  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQJS_NS=1 -G "Visual Studio 17 2022" -A x64 ..
 ) else (
-  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "Visual Studio 16 2019" -A x64 ..
+  cmake -S ..\CMakeLists.win.txt -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "Visual Studio 17 2022" -A x64 ..
 )
 
 popd

--- a/win/make_win64md.bat
+++ b/win/make_win64md.bat
@@ -1,9 +1,9 @@
 mkdir build & pushd build
 
 if "%1" == "1" (
-  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQJS_NS=1 -G "Visual Studio 16 2019" -A x64 ..
+  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DQJS_NS=1 -G "Visual Studio 17 2022" -A x64 ..
 ) else (
-  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "Visual Studio 16 2019" -A x64 ..
+  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -G "Visual Studio 17 2022" -A x64 ..
 )
 popd
 cmake --build build --config Release

--- a/win/make_win64md_dll.bat
+++ b/win/make_win64md_dll.bat
@@ -1,9 +1,9 @@
 copy /y ..\build\libquickjs.dll.a ..\build\libquickjs.dll.lib
 mkdir build & pushd build
 if "%1" == "1" (
-  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DWIN_DLL=1 -DQJS_NS=1 -G "Visual Studio 16 2019" -A x64 ..
+  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DWIN_DLL=1 -DQJS_NS=1 -G "Visual Studio 17 2022" -A x64 ..
 ) else (
-  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DWIN_DLL=1 -G "Visual Studio 16 2019" -A x64 ..
+  cmake -DMD=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DWIN_DLL=1 -G "Visual Studio 17 2022" -A x64 ..
 )
 popd
 cmake --build build --config Release


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b56ce08b-0366-454b-b98a-476b513d3088)

remove this DLL dependency to avoid failures in Win11.




Only win11 is tested for this PR.