### PR TITLE
QuickJS问题修复

### DIFF
--- a/quickjs/quickjs.c
+++ b/quickjs/quickjs.c
@@ -48759,7 +48759,18 @@ static void map_delete_record(JSRuntime *rt, JSMapState *s, JSMapRecord *mr)
 {
     if (mr->empty)
         return;
-    
+    uint32_t h = map_hash_key(mr->key, s->hash_bits);
+    JSMapRecord* curr, * prev = NULL;
+    for (curr = s->hash_table[h]; curr != NULL; prev = curr, curr = curr->hash_next) {
+        if (curr == mr) {
+            if (prev)
+                prev->hash_next = mr->hash_next;
+            else
+                s->hash_table[h] = mr->hash_next;
+            mr->hash_next = NULL;
+            break;
+        }
+    }//加入移除操作
     if (s->is_weak) {
         js_weakref_free(rt, mr->key);
     } else {

--- a/src/v8-impl.cc
+++ b/src/v8-impl.cc
@@ -325,7 +325,7 @@ bool Value::IsArray() const {
 }
 
 bool Value::IsBigInt() const {
-    return JS_VALUE_GET_TAG(value_) == JS_TAG_BIG_INT;
+    return JS_VALUE_GET_TAG(value_) == JS_TAG_BIG_INT || JS_VALUE_GET_TAG(value_) == JS_TAG_SHORT_BIG_INT;
 }
 
 bool Value::IsBoolean() const {


### PR DESCRIPTION
1、map delete 元素后节点没从链表中移除，成为野指针，后续访问会闪退
2、bigint判定漏了short_big_int的判定